### PR TITLE
Update repo and template name in config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,8 +6,8 @@ tags:
   - Workflows
   - Hello World
 template:
-    name: hello-world-actions
-    repo: hello-world-actions-template
+    name: hello-github-actions
+    repo: hello-github-actions-template
 before:
 # protect the master branch
 - type: updateBranchProtection


### PR DESCRIPTION
When I was importing this course to test, I ran into an error:

`02:59:04There was an error retrieving your template repository. Ensure that it is owned by github.`

I believe the problem is that the `config.yml` was not referencing the correct template repository. This PR resolves that.

cc @crichID @hectorsector 