### PR TITLE
Add a step to remove branch protection before last merge

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -166,6 +166,7 @@ steps:
         event: APPROVE
         data:
           repo: "%payload.repository.html_url%"
+      - type: removeBranchProtection
 
   # 7 - Incorporate the action
   - title: Incorporate the workflow


### PR DESCRIPTION
This pull request fixes #13 by removing branch protection before asking users to merge the final step. This shouldn't be _required_, but some users have been getting stuck because the page doesn't auto-update after the bot approves the pull request.
