### PR TITLE
Add runs-on details

### DIFF
--- a/responses/05.0_trigger.md
+++ b/responses/05.0_trigger.md
@@ -3,6 +3,7 @@ Nice, you just added an action block to your workflow file! Here are some import
 - `jobs:` is the base component of a workflow run
 - `build:` is the identifier we're attaching to this job
 - `name:` is the name of the job, this is displayed on GitHub when the workflow is running
+- `runs-on:` is **required** for the type of machine the job [`runs-on`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on). The machine can be either a GitHub-hosted runner or a self-hosted runner.
 - `steps:` the linear sequence of operations that make up a job
 - `uses: actions/checkout@v1` uses a community action called [`checkout`](https://github.com/actions/checkout) to allow the workflow to access the contents of the repository
 - `uses: ./action-a` provides the relative path the action we've created in the `action-a` directory of the repository

--- a/responses/05.0_trigger.md
+++ b/responses/05.0_trigger.md
@@ -3,7 +3,7 @@ Nice, you just added an action block to your workflow file! Here are some import
 - `jobs:` is the base component of a workflow run
 - `build:` is the identifier we're attaching to this job
 - `name:` is the name of the job, this is displayed on GitHub when the workflow is running
-- `runs-on:` is **required** for the type of machine the job [`runs-on`](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on). The machine can be either a GitHub-hosted runner or a self-hosted runner.
+- `runs-on:` defines the type of machine to run the job on. The machine can be either a GitHub-hosted runner or a self-hosted runner.
 - `steps:` the linear sequence of operations that make up a job
 - `uses: actions/checkout@v1` uses a community action called [`checkout`](https://github.com/actions/checkout) to allow the workflow to access the contents of the repository
 - `uses: ./action-a` provides the relative path the action we've created in the `action-a` directory of the repository


### PR DESCRIPTION
This was missing, and the `runs-on:` is required for the action block.