### PR TITLE
Upgrade GitHub Checkout Action to v2 and updated instruction

### DIFF
--- a/responses/01.0_docker-success.md
+++ b/responses/01.0_docker-success.md
@@ -13,7 +13,7 @@ An entrypoint script must exist in our repository so that Docker has something t
 ### :keyboard: Activity: Add an entrypoint script and commit it to your branch
 
 1. As a part of this branch and pull request, create a file in the `/action-a/` directory titled `entrypoint.sh`. You can do so with [this quicklink]({{ actionAUrl }})
-1. Add the following content to the `entrypoint.sh` file:
+1. Add the following content to the `entrypoint.sh` file. Later in this tutorial, **$INPUT_MY_NAME** is going to get a value from **MY_NAME**.
 
    ```shell
    #!/bin/sh -l

--- a/responses/02.0_entrypoint-success.md
+++ b/responses/02.0_entrypoint-success.md
@@ -15,7 +15,7 @@ We will use an `input` parameter to read in the value of `MY_NAME`.
 ### :keyboard: Activity: Create action.yml
 
 1. As a part of this branch and pull request, create a file titled `action-a/action.yml`. You can do so using [this quicklink]({{ actionAUrl }}) or manually.
-1. Add the following content to the `action.yml` file:
+1. Add the following content to the `action.yml` file. Feel free to change the values for **author**, **description** and **default** under **MY_NAME**, and **property values** under **branding**. You can visit [**Metadata syntax for GitHub Actions**](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions) to learn more about Metadata syntax, particular about [**branding**](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding).
 
    ```yaml
    name: "Hello Actions"

--- a/responses/03.0_actionyml-success.md
+++ b/responses/03.0_actionyml-success.md
@@ -2,7 +2,7 @@ Next, we'll define a **workflow** that uses the GitHub Action.
 
 ### Workflow Files
 
-Workflows are defined in special files in the `.github/workflows` directory, named `main.yml`.
+[**Workflows**](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions) are defined in special files in the `.github/workflows` directory, named `main.yml`.
 
 Workflows can execute based on your chosen event. For this lab, we'll be using the [`push`](https://developer.github.com/v3/activity/events/types/#pushevent) event.
 

--- a/responses/04.0_workflow-block-success.md
+++ b/responses/04.0_workflow-block-success.md
@@ -9,7 +9,7 @@ Next, we need to specify a job or jobs to run.
 
 ### Actions
 
-Workflows piece together jobs, and jobs piece together steps. We'll now create a job that runs an action. Actions can be used from within the same repository, from any other public repository, or from a published Docker container image. We'll use an action that we'll define in this repository.
+Workflows piece together jobs, and jobs piece together steps. We'll now create a job that runs an action. Actions can be used from within the same repository, from any other public repository, or from a published Docker container image. We'll use an action that we'll define in this repository. This specific workflow utilizes **GitHub Action** called [**Checkout V2**](https://github.com/actions/checkout).
 
 We'll add the block now, and break it down in the next step.
 
@@ -19,15 +19,17 @@ Let's add the expected action to the workflow.
 
 ### :keyboard: Activity: Add an action block to your workflow file
 
-1. As a part of this branch and pull request, [edit `.github/workflows/main.yml`]({{ workflowEditUrl }}) to append the following content:
+1. As a part of this branch and pull request, [edit `.github/workflows/main.yml`]({{ workflowEditUrl }}) to append the following content. Feel free to replace the value of **MY_NAME** with your name or something that you want to be printing out. 
    ```yaml
    jobs:
      build:
        name: Hello world action
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v1
-         - uses: ./action-a
+         - name: Check out repository
+           uses: actions/checkout@v2
+         - name: Use local action-a directory
+           uses: ./action-a
            with:
              MY_NAME: "Mona"
    ```


### PR DESCRIPTION
Updated the following:

- **01.0_docker-success.md:** Added an additional sentence to explain about **$INPUT_My_NAME**, which is ambiguous
- **02.0_entrypoint-success.md:** Added reference links to [**Metadata Syntax**](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding) and provided an instruction that you can modify
- **03.0_actionyml-success.md**: Added a link to [**Workflow Syntax**](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
- **04.0_workflow-block-success.md**: Provided a link to [**GitHub Actions for Checkout V2**](https://github.com/actions/checkout), upgraded the GitHub Checkout Actions to v2, and added for each step in the job