### PR TITLE
Typo in text

### DIFF
--- a/responses/05.0_trigger.md
+++ b/responses/05.0_trigger.md
@@ -11,7 +11,7 @@ Nice, you just added an action block to your workflow file! Here are some import
 
 ### Your action has been triggered!
 
-Your repository now contains an action (defined in the `/action-a/` folder) and a workflow (defined in the `./github/workflows/main.yml` file).
+Your repository now contains an action (defined in the `/action-a/` folder) and a workflow (defined in the `/.github/workflows/main.yml` file).
 
 This action will run any time a new commit is created or pushed to the remote repository. Since you just created a commit, the workflow should have been triggered. This might take a few minutes since it's the first time running in this repository.
 


### PR DESCRIPTION
Hello! During the training noticed typo in 6th step:

>Your repository now contains an action (defined in the /action-a/ folder) and a workflow (defined in the ./github/workflows/main.yml file).

Maybe the period before first slash is incorrect?